### PR TITLE
Fix code block example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Add a content security policy to the ENV= { … } in config/environment.js. Othe
 In controller files that make use of the websocket:
 Add an init function that finds the websocket connection, saves it to a variable, and maps controller functions to socket messages/states
 You can also contact the websocket from Ember via actions.
+
     ...
     init: function() {
         this._super();


### PR DESCRIPTION
Hi there, was reading the docs and found a small typo. The code example was hidden in a paragraph and hard to read. This should fix it up!
